### PR TITLE
Fix connectUrl

### DIFF
--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -278,7 +278,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     let connect_url =
       "https://" + combinedObject.url_abbreviation + "-openpath.nrel.gov/api/";
     configObject["server"] = {
-      connectURL: connect_url,
+      connectUrl: connect_url,
       aggregate_call_auth: "user_only",
     }; //TODO check options for call + add to form?
 


### PR DESCRIPTION
Before, the github issue form would generate `connectURL` but the app expects `connectUrl`